### PR TITLE
Update optimize command to use 'Quest 2 or later'

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -1184,7 +1184,7 @@
               },
               {
                 "name": "8. Codec Selection",
-                "value": "Switch to the H.264 codec on the desktop streaming app to improve latency slightly (the benefit is greater on the Quest 1) otherwise using Automatic is recommended. For Quest 2 you can enable HEVC in the Streamer app for better image quality and reduce your video bitrate to decrease required throughput, which may be more beneficial for some networks environments.",
+                "value": "Switch to the H.264 codec on the desktop streaming app to improve latency slightly (the benefit is greater on the Quest 1) otherwise using Automatic is recommended. For Quest 2 or later you can enable HEVC in the Streamer app for better image quality and reduce your video bitrate to decrease required throughput, which may be more beneficial for some networks environments.",
                 "inline": false
               },
               {


### PR DESCRIPTION
This PR updates the commands.json file with the following change:

- In the 'optimize' command "Codec Selection" section, changed "For Quest 2 you can enable HEVC..." to "For Quest 2 or later you can enable HEVC..." to simplify the reference to newer Quest headsets without listing each model individually.

This change was requested to make the command text more concise and future-proof.

Closes #58

Generated with [Claude Code](https://claude.ai/code)