### PR TITLE
Update drivers command to clarify GPU driver requirements

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -549,7 +549,7 @@
     "ephemeral": false,
     "embed": {
       "title": "Recommended GPU Drivers",
-      "description": "NVIDIA RTX 30/40 Series: [566.36](https://www.nvidia.com/en-us/geforce/drivers/results/237719/)\n\nNVIDIA: [Latest](https://www.nvidia.com/en-us/software/nvidia-app/)\n\nAMD RX 400/500/VEGA series: [20.10.1](https://www.guru3d.com/download/amd-radeon-adrenalin-edition-20-10-1-driver-download/) (newer versions can have HEVC crashing issues)\n\nAMD 5000/6000/7000/9000 series: [25.3.1](https://www.amd.com/en/resources/support-articles/release-notes/RN-RAD-WIN-25-3-1.html)"
+      "description": "NVIDIA RTX 30/40 Series: [566.36](https://www.nvidia.com/en-us/geforce/drivers/results/237719/)\n\nAll Other NVIDIA GPUs: [Latest](https://www.nvidia.com/en-us/software/nvidia-app/)\n\nAMD RX 400/500/VEGA series: [20.10.1](https://www.guru3d.com/download/amd-radeon-adrenalin-edition-20-10-1-driver-download/) (newer versions can have HEVC crashing issues)\n\nAMD 5000/6000/7000/9000 series: [25.3.1](https://www.amd.com/en/resources/support-articles/release-notes/RN-RAD-WIN-25-3-1.html)"
     }
   },
   {


### PR DESCRIPTION
This PR updates the commands.json file with the following changes:

- In the "drivers" command, changed "NVIDIA: [Latest]" to "All Other NVIDIA GPUs: [Latest]" to clarify that all NVIDIA GPUs except the 30/40 series should use the latest driver
- NVIDIA RTX 30/40 Series remains unchanged at driver version 566.36

This change makes it clearer which driver version each GPU series should use.

Fixes #67

Generated with [Claude Code](https://claude.ai/code)