### PR TITLE
Update Roblox command with oculus plugin compatibility step

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -515,7 +515,7 @@
     "ephemeral": false,
     "embed": {
       "title": "Play Roblox in VR",
-      "description": "1. Set SteamVR as default OpenXR Runtime.\n2. Launch SteamVR from the button in the Virtual Desktop menu in VR.\n3. Switch back to desktop and Launch Roblox.\n4. Toggle VR mode in Roblox.",
+      "description": "1. Set SteamVR as default OpenXR Runtime.\n2. Launch SteamVR from the button in the Virtual Desktop menu in VR.\n3. Open SteamVR settings, go to OpenXR, then disable \"oculus plugin compatibility\".\n4. Switch back to desktop and Launch Roblox.\n5. Toggle VR mode in Roblox.",
       "footer": {
         "text": "Please note, Roblox's VR support is quite buggy."
       }


### PR DESCRIPTION
This PR updates the commands.json file with the following changes:

- Updated the 'roblox' command to add a new step about disabling "oculus plugin compatibility" in SteamVR settings
- The new step was inserted as step 3: "Open SteamVR settings, go to OpenXR, then disable 'oculus plugin compatibility'."
- Previous steps 3 and 4 were renumbered to become steps 4 and 5
- The total number of steps increased from 4 to 5

Closes #69

Generated with [Claude Code](https://claude.ai/code)