### PR TITLE
feat: add wifistandards command with 320MHz and AC dual-band support

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -674,6 +674,15 @@
     }
   },
   {
+    "name": "wifistandards",
+    "description": "WiFi Standards and Bands Explained",
+    "ephemeral": false,
+    "embed": {
+      "title": "WiFi Standards and Bands Explained",
+      "description": "**Modern WiFi Standards Evolution:**\n• **802.11ac/WiFi 5 (2013)** - 2.4/5GHz\n• **802.11ax/WiFi 6 (2019)** - 2.4/5GHz\n• **802.11ax/WiFi 6E (2020)** - with 6GHz band\n• **802.11be/WiFi 7 (2024)** - 2.4/5/6GHz\n\n**Frequency Bands:**\n• **2.4GHz** - Longer range, more interference, 3 non-overlapping channels (not suitable for PC VR gaming)\n• **5GHz** - Shorter range, less interference, 25 non-overlapping channels  \n• **6GHz** - Shortest range, minimal interference, 59 channels (WiFi 6E/7)\n\n**Channel Widths Impact:**\n• **20MHz** - Most compatible, lowest speeds\n• **40MHz** - 2x speed of 20MHz\n• **80MHz** - 2x speed of 40MHz (recommended for VR)\n• **160MHz** - 2x speed of 80MHz (recommended for 6GHz only due to congestion)\n• **320MHz** - 2x speed of 160MHz (WiFi 7 only, 6GHz band)\n\n**Real-World VR Streaming Speeds:**\n• **WiFi 5 (AC)** - Streaming: ~200 Mbps | Max Link: 867 Mbps\n• **WiFi 6 (AX)** - Streaming: ~400 Mbps | Max Link: 1200 Mbps\n• **WiFi 6E (AXE)** - Streaming: ~600 Mbps | Max Link: 2400 Mbps\n• **WiFi 7 (BE)** - Streaming: ~600 Mbps | Max Link: 5800 Mbps\n\nNote: Actual speeds depend on router quality, distance, interference, and channel width settings."
+    }
+  },
+  {
     "name": "limit",
     "description": "Limitations",
     "ephemeral": false,


### PR DESCRIPTION
This PR updates the commands.json file with the following changes:

- Added a new command called 'wifistandards' that provides a comprehensive explanation of WiFi standards and frequency bands
- In the Channel Widths Impact section, added "320MHz - 2x speed of 160MHz (WiFi 7 only, 6GHz band)" as the highest channel width option
- In the Modern WiFi Standards Evolution section, changed WiFi 5 (AC) from "5GHz only" to "2.4/5GHz" to accurately reflect that 802.11ac supports both frequency bands
- The command maintains all previously requested features:
  - Modern WiFi Standards Evolution starting with WiFi 5 (minimum for Virtual Desktop)
  - Note that 2.4GHz is "(not suitable for PC VR gaming)"
  - 160MHz is "(recommended for 6GHz only due to congestion)"
  - Real-World VR Streaming Speeds showing both streaming speeds and max link speeds
- The command was placed after the 'ptc' command and before the 'limit' command to keep WiFi-related commands grouped together

Resolves #72

Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: OpenSorce1 <OpenSorce1@users.noreply.github.com>